### PR TITLE
Strscan in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem "decidim-term_customizer", git: "https://github.com/mainio/decidim-module-te
 
 gem "deface", ">= 1.9"
 
+gem "strscan", ">=3.1.0"
+
 group :development, :test do
   gem "faker", "~> 2.14"
   gem "rubocop-faker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -926,6 +926,7 @@ DEPENDENCIES
   sidekiq-cron
   spring
   spring-watcher-listen (~> 2.0)
+  strscan (>= 3.1.0)
   uglifier (~> 4.1)
   web-console (~> 3.5)
 


### PR DESCRIPTION
Added gem strscan >=3.1.0
This fixes the production server from crashing after the most recent Decidim bump to 0.27.6